### PR TITLE
Add Development and UI Preview modes to the Dark theme demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ You can find it [here](./demo/README.md).
   * You can use the jsdeliver CDN to pull it directly from GitHub: https://cdn.jsdelivr.net/gh/jenkinsci/dark-theme@master/theme.css
 
 More detailed testing guidelines are coming soon!
+
+### Development
+
+The pre-configured Docker image can be also used for development purposes.
+You can find the guide [here](./demo/README.md#development).

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -16,3 +16,6 @@ RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 # Inject configuration
 COPY enable-theme.groovy /usr/share/jenkins/ref/init.groovy.d/enable-theme.groovy
 RUN mkdir /usr/share/jenkins/ref/userContent
+
+COPY jenkins3.sh /usr/local/bin/jenkins3.sh
+ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins3.sh"]

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -3,4 +3,13 @@ build:
 
 #TODO: Add for Pipeline development demo: -v maven-repo:/root/.m2 -v ${MY_PIPELINE_LIBRARY_DIR}:/var/jenkins_home/pipeline-library -v ${MY_OTHER_PIPELINE_LIBS_DIRS}:/var/jenkins_home/pipeline-libs -e DEV_HOST=${CURRENT_HOST}
 run:
-	docker run --rm  -v $(CURDIR)/../theme.css:/usr/share/jenkins/ref/userContent/theme.css -p 8080:8080 -p 50000:50000 jenkins4eval/dark-theme
+	docker run --rm  -p 8080:8080 -p 50000:50000 jenkins4eval/dark-theme
+
+run-preview:
+	docker run --rm  -e EXPERIMENTAL_UI=true -p 8080:8080 -p 50000:50000 jenkins4eval/dark-theme
+
+devel:
+	docker run --rm  -e DEVEL=true -v $(CURDIR)/../theme.css:/usr/share/jenkins/ref/userContent/theme.css -p 8080:8080 -p 50000:50000 jenkins4eval/dark-theme
+
+devel-preview:
+	docker run --rm  -e EXPERIMENTAL_UI=true -e DEVEL=true -v $(CURDIR)/../theme.css:/usr/share/jenkins/ref/userContent/theme.css -p 8080:8080 -p 50000:50000 jenkins4eval/dark-theme

--- a/demo/README.md
+++ b/demo/README.md
@@ -11,12 +11,26 @@ You will need Docker and make to run this demo.
 
 1. `make build` - will build the demo image.
 2. `make run` will run the image.
+   You can also use `make run-preview` to run the theme with other UI improvements which are in preview.
 3. Go to the `http://localhost:8080`.
-4. Login with one of the user accounts.
+4. Login with one of the user accounts (see below).
+5. Try out the theme, submit a GitHub Issue to this repository if you discover any compatibility issues.
+
+For advanced use-cases, please see the documentation in [oleg-nenashev/demo-jenkins-config-as-code](https://github.com/oleg-nenashev/demo-jenkins-config-as-code).
+
+### User accounts
+
+There
+
   * `admin/admin` - for a user with full administrative access
   * `readonly/readonly` - user with global read-only access (System Read, Extended Read for jobs and agents)
   * `manager/manager` - user with global Manage permissions
   * `user/user` - common Jenkins user with access to some jobs on the instance
-5. Try out the theme, submit a GitHub Issue to this repository if you discover any compatibility issues.
 
-For advanced use-cases, please see the documentation in [oleg-nenashev/demo-jenkins-config-as-code](https://github.com/oleg-nenashev/demo-jenkins-config-as-code).
+### Development mode
+
+By default the demo uses a dark theme from the master branch in GitHub.
+If you want to make changes locally and test them, use the following commands:
+
+* `make dev` - for the default UI
+* `make dev-preview` - Jenkins UI with the preview features enabled

--- a/demo/enable-theme.groovy
+++ b/demo/enable-theme.groovy
@@ -4,7 +4,12 @@ import jenkins.model.Jenkins
 import hudson.model.PageDecorator
 import org.jenkinsci.plugins.simpletheme.CssUrlThemeElement;
 
+boolean developerMode = Boolean.getBoolean("io.jenkins.themes.dark.developerMode")
+String themeUrl = developerMode
+    ? "http://localhost:8080/userContent/theme.css"
+    : "https://cdn.jsdelivr.net/gh/jenkinsci/dark-theme@master/theme.css"
+
 //TODO(oleg_nenashev): Use a theme served from a volume
 Jenkins.instance.getExtensionList(PageDecorator.class)
     .get(SimpleThemeDecorator.class).getElements()
-        .add(new CssUrlThemeElement("https://cdn.jsdelivr.net/gh/jenkinsci/dark-theme@master/theme.css"))
+        .add(new CssUrlThemeElement(themeUrl))

--- a/demo/jenkins3.sh
+++ b/demo/jenkins3.sh
@@ -1,0 +1,19 @@
+#! /bin/bash -e
+# Additional wrapper, which adds custom environment options for the run
+
+extra_java_opts=( )
+
+if [[ "$DEVEL" ]] ; then
+  extra_java_opts+=( \
+    '-Dio.jenkins.themes.dark.developerMode=true' \
+  )
+fi
+
+if [[ "$EXPERIMENTAL_UI" ]] ; then
+  extra_java_opts+=( \
+    '-Djenkins.ui.refresh=true' \
+  )
+fi
+
+export JAVA_OPTS="$JAVA_OPTS ${extra_java_opts[@]}"
+exec /usr/local/bin/jenkins2.sh "$@"


### PR DESCRIPTION
Now you an also use the demo for evaluating the UI preview mode with the dark theme and for development. Development is limited, because browsing caching is too good. So there is no stable live reload at the moment unfortunately.

