### PR TITLE
Fix permissions for the exec file on DockerHub

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -18,4 +18,5 @@ COPY enable-theme.groovy /usr/share/jenkins/ref/init.groovy.d/enable-theme.groov
 RUN mkdir /usr/share/jenkins/ref/userContent
 
 COPY jenkins3.sh /usr/local/bin/jenkins3.sh
+RUN chmod +x /usr/local/bin/jenkins3.sh
 ENTRYPOINT ["tini", "--", "/usr/local/bin/jenkins3.sh"]


### PR DESCRIPTION
As reported by @ksenia-nenasheva , the demo does not work when using the DockerHub image. The file permissions are wrong. My local build passes permissions, but Docker for Windows might be messing with permissions. So I am applying a quick fix.
